### PR TITLE
fix redirect issue for non-default wp-admin urls

### DIFF
--- a/auto-login-with-cloudflare.php
+++ b/auto-login-with-cloudflare.php
@@ -144,7 +144,7 @@ function login()
                 wp_set_current_user($user_id);
                 add_action('init', function () use ($user) {
                     do_action('wp_login', $user->name, $user);
-                    wp_safe_redirect('/wp-admin');
+                    wp_safe_redirect(admin_url());
                     exit;
                 });
             }


### PR DESCRIPTION
Fixed constant variable for admin url in line 147. Static /wp-admin was inserted there. If admin url is like /wp/wp-admin or sth else you will end in a redirect loop after login with cloudflare. Changing this to admin_url() function will fix this behaviour.